### PR TITLE
manually set timeout to catch ECONNREFUSED in parser

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -103,6 +103,14 @@ class Parser {
       req.setTimeout(this.options.timeout, () => {
         return reject(new Error("Request timed out after " + this.options.timeout + "ms"));
       });
+      let socketTimout = this.options.timeout;
+      req.on('socket', function(socket) {
+        setTimeout(() => {
+          if (socket.connecting) {
+            return reject(new Error("Request timed out after " + socketTimout + "ms. The connection may have been refused."));
+          }
+        }, socketTimout)
+      })
       req.on('error', reject);
     });
     prom = utils.maybePromisify(callback, prom);

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -100,18 +100,10 @@ class Parser {
           return this.parseString(xml).then(resolve, reject);
         });
       })
-      req.setTimeout(this.options.timeout, () => {
-        return reject(new Error("Request timed out after " + this.options.timeout + "ms"));
-      });
-      let socketTimout = this.options.timeout;
-      req.on('socket', function(socket) {
-        setTimeout(() => {
-          if (socket.connecting) {
-            return reject(new Error("Request timed out after " + socketTimout + "ms. The connection may have been refused."));
-          }
-        }, socketTimout)
-      })
       req.on('error', reject);
+      setTimeout(() => {
+        return reject(new Error("Request timed out after " + this.options.timeout + "ms"));
+      }, this.options.timeout);
     });
     prom = utils.maybePromisify(callback, prom);
     return prom;

--- a/test/parser.js
+++ b/test/parser.js
@@ -253,6 +253,20 @@ describe('Parser', function() {
     });
   });
 
+  it('should respect timeout option if the socket does not connect', function(done) {
+    var server = HTTP.createServer(function(req, res) {});
+    server.listen(function() {
+      var port = server.address().port;
+      var url = 'http://localhost:80';
+      var parser = new Parser({timeout: 1});
+      parser.parseURL(url, function(err, parsed) {
+        Expect(err).to.not.equal(null);
+        Expect(err.message).to.equal("Request timed out after 1ms. The connection may have been refused.");
+        done();
+      });
+    });
+  });
+
   it('should parse itunes categories', function(done) {
     testParseForFile('itunes-category', 'rss', done);
   });

--- a/test/parser.js
+++ b/test/parser.js
@@ -253,20 +253,6 @@ describe('Parser', function() {
     });
   });
 
-  it('should respect timeout option if the socket does not connect', function(done) {
-    var server = HTTP.createServer(function(req, res) {});
-    server.listen(function() {
-      var port = server.address().port;
-      var url = 'http://localhost:80';
-      var parser = new Parser({timeout: 1});
-      parser.parseURL(url, function(err, parsed) {
-        Expect(err).to.not.equal(null);
-        Expect(err.message).to.equal("Request timed out after 1ms. The connection may have been refused.");
-        done();
-      });
-    });
-  });
-
   it('should parse itunes categories', function(done) {
     testParseForFile('itunes-category', 'rss', done);
   });


### PR DESCRIPTION
Trying to solve #146 

The first thing I did was try and swap out the working localhost connection for a url I knew was failing with ECONNREFUSED. 

The test suite started failing like this: 

```
3) Parser
       should respect timeout option:
     Error: Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/mnt/d/dev/rss-parser/test/parser.js)
```

I checked the Node [reference for setTimeout in the HTTP module](https://nodejs.org/api/http.html#http_request_settimeout_timeout_callback) and noticed something in the history notes: 

```
Consistently set socket timeout only when the socket connects.
```

So I'm wondering if my ECONNREFUSED error **stops the socket from connecting**. Which means we might need to catch that error elsewhere. I searched for "ECONNREFUSED node http" and found (a StackOverflow post)[https://stackoverflow.com/questions/8381198/catching-econnrefused-in-node-js-with-http-request] that might help. 

This is a piece of code that helped me hone in on it: 

```
msg.on('socket', function(socket) { 
        socket.setTimeout(2000, function () {   // set short timeout so discovery fails fast
            var e = new Error ('Timeout connecting to ' + queryObj.ip));
            e.name = 'Timeout';
            badNews(e);
            msg.abort();    // kill socket
        });
        socket.on('error', function (err) { // this catches ECONNREFUSED events
            badNews(err);
            msg.abort();    // kill socket
        });
    }); // handle connection events and errors
```

I looked up the [net.socket documentation](https://nodejs.org/api/net.html) to see what events we can listen to on the socket. It looks like we're getting the `lookup` event, but not the `connect` event. 

What's more, I don't think the ECONNREFUSED is tripping yet or otherwise setting the `error` on the `lookup` event. 

A lot of the solutions for this problem have separate try/catch statements around the GET or request methods in the HTTP/HTTPS modules. But those statements don't check for timeouts. For whatever reason, the `setTimeout` method is **not correctly passing the timeout value down to the socket**. 

It feels like a hacky fix around it, but I set a timeout function with the timeout option provided to rss-parser and check if `socket.connecting` is still true. If it is, we reject and give a message that the connection might have been refused. 

I think we can avoid the hacky solution if: 

1. We figure out how to correctly pass the timeout value to the socket 
2. We can figure out where the ECONNREFUSED or similar error is happening and come up with a smarter way to catch it within the timeout. 

What do you think? 