### PR TITLE
Update ts definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,9 +6,11 @@ declare namespace Parser {
     readonly 'User-Agent'?: string;
   }
 
+  type CustomFieldItem = string | { keepArray: boolean }
+    
   export interface CustomFields {
     readonly feed?: string[];
-    readonly item?: string[] | string[][];
+    readonly item?: CustomFieldItem[] | CustomFieldItem[][];
   }
 
   export interface ParserOptions {


### PR DESCRIPTION
In the docs, there is a "keepArray" object/boolean that could be given to `customFields.items` in the rss parser config. The TS definitions only allowed for a string. This PR rectifies that.