### PR TITLE
Add requestOptions passthrough 

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,9 +207,9 @@ let parser = new Parser({maxRedirects: 100});
 ### Request passthrough
 `rss-parser` uses [http](https://nodejs.org/docs/latest/api/http.html#http_http_get_url_options_callback)/[https](https://nodejs.org/docs/latest/api/https.html#https_https_get_url_options_callback) module
 to do requests. You can pass [these options](https://nodejs.org/docs/latest/api/https.html#https_https_request_options_callback)
-to `https.get()` by specifying `options.requestOptions`:
+to `http.get()`/`https.get()` by specifying `options.requestOptions`:
 
-e.g. to allowing unauthorized certificate
+e.g. to allow unauthorized certificate
 ```js
 let parser = new Parser({
   requestOptions: {

--- a/README.md
+++ b/README.md
@@ -204,6 +204,19 @@ with `options.maxRedirects`.
 let parser = new Parser({maxRedirects: 100});
 ```
 
+### Request passthrough
+`rss-parser` uses [http](https://nodejs.org/docs/latest/api/http.html#http_http_get_url_options_callback)/[https](https://nodejs.org/docs/latest/api/https.html#https_https_get_url_options_callback) module
+to do requests. You can pass [these options](https://nodejs.org/docs/latest/api/https.html#https_https_request_options_callback)
+to `https.get()` by specifying `options.requestOptions`:
+
+e.g. to allowing unauthorized certificate
+```js
+let parser = new Parser({
+  requestOptions: {
+    rejectUnauthorized: false
+  }
+});
+```
 
 ## Contributing
 Contributions are welcome! If you are adding a feature or fixing a bug, please be sure to add a [test case](https://github.com/bobby-brennan/rss-parser/tree/master/test/input)

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,5 @@
 import { Options } from 'xml2js';
+import { RequestOptions } from 'https';
 
 declare namespace Parser {
   export interface Headers {
@@ -15,6 +16,7 @@ declare namespace Parser {
 
   export interface ParserOptions {
     readonly xml2js?: Options;
+    readonly requestOptions?: RequestOptions;
     readonly headers?: Headers;
     readonly defaultRSS?: number;
     readonly maxRedirects?: number;

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -21,6 +21,7 @@ class Parser {
     options.customFields = options.customFields || {};
     options.customFields.item = options.customFields.item || [];
     options.customFields.feed = options.customFields.feed || [];
+    options.requestOptions = options.requestOptions || {};
     if (!options.maxRedirects) options.maxRedirects = DEFAULT_MAX_REDIRECTS;
     if (!options.timeout) options.timeout = DEFAULT_TIMEOUT;
     this.options = options;
@@ -81,6 +82,7 @@ class Parser {
         hostname: urlParts.hostname,
         port: urlParts.port,
         path: urlParts.path,
+        ...this.options.requestOptions,
       }, (res) => {
         if (this.options.maxRedirects && res.statusCode >= 300 && res.statusCode < 400 && res.headers['location']) {
           if (redirectCount === this.options.maxRedirects) {


### PR DESCRIPTION
Fix #137

Might also be useful in other situations

We can also use [@types/node](https://www.npmjs.com/package/@types/node) to validate the types, but I am not sure if you would like to add another dependency to this lib.