### PR TITLE
Update parser to use nsb:id

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -207,6 +207,8 @@ class Parser {
       if (xmlItem.guid) {
         item.guid = xmlItem.guid[0];
         if (item.guid._) item.guid = item.guid._;
+      }else if(xmlItem['$'] && xmlItem['$']['nsb:id']){
+        item.guid = xmlItem['$']['nsb:id'];
       }
       if (xmlItem.category) item.categories = xmlItem.category;
       this.setISODate(item);


### PR DESCRIPTION
Some RSS Streams hide the id of an item in the item tag: `<item nsb:id="79508">...</item>`
It might be better to pass it as an argument to the parser to allow for more flexibility.