### PR TITLE
Ensure that gitignore rules are followed.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,5 @@
-/test
+node_modules/
+*.swp
+.idea/
+dist/stats.json
+test


### PR DESCRIPTION
If there is an `.npmignore`, the `.gitignore` file does nothing, and only the `.npmignore` file gets consulted, so right now installing 3.8.0 still means people get the "not relevant for dist at all" 1.4MB `stats.json` file =)