### PR TITLE
extract parseItemAtom() and parseItemRss() methods

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -126,10 +126,7 @@ class Parser {
     if (xmlObj.feed.updated) {
       feed.lastBuildDate = xmlObj.feed.updated[0];
     }
-    (xmlObj.feed.entry || []).forEach(entry => {
-      let item = this.parseItemAtom(entry);
-      feed.items.push(item);
-    });
+    feed.items = (xmlObj.feed.entry || []).map(entry => this.parseItemAtom(entry));
     return feed;
   }
 
@@ -199,10 +196,7 @@ class Parser {
       if (image.height) feed.image.height = image.height[0];
     }
     utils.copyFromXML(channel, feed, feedFields);
-    items.forEach(xmlItem => {
-      let item = this.parseItemRss(xmlItem, itemFields);
-      feed.items.push(item);
-    });
+    feed.items = items.map(xmlItem => this.parseItemRss(xmlItem, itemFields));
     return feed;
   }
 

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -127,30 +127,35 @@ class Parser {
       feed.lastBuildDate = xmlObj.feed.updated[0];
     }
     (xmlObj.feed.entry || []).forEach(entry => {
-      let item = {};
-      utils.copyFromXML(entry, item, this.options.customFields.item);
-      if (entry.title) {
-        let title = entry.title[0] || '';
-        if (title._) title = title._;
-        if (title) item.title = title;
-      }
-      if (entry.link && entry.link.length) {
-        item.link = utils.getLink(entry.link, 'alternate', 0);
-      }
-      if (entry.published && entry.published.length && entry.published[0].length) item.pubDate = new Date(entry.published[0]).toISOString();
-      if (!item.pubDate && entry.updated && entry.updated.length && entry.updated[0].length) item.pubDate = new Date(entry.updated[0]).toISOString();
-      if (entry.author && entry.author.length && entry.author[0].name && entry.author[0].name.length) item.author = entry.author[0].name[0];
-      if (entry.content && entry.content.length) {
-        item.content = utils.getContent(entry.content[0]);
-        item.contentSnippet = utils.getSnippet(item.content)
-      }
-      if (entry.id) {
-        item.id = entry.id[0];
-      }
-      this.setISODate(item);
+      let item = this.parseItemAtom(entry);
       feed.items.push(item);
     });
     return feed;
+  }
+
+  parseItemAtom(entry) {
+    let item = {};
+    utils.copyFromXML(entry, item, this.options.customFields.item);
+    if (entry.title) {
+      let title = entry.title[0] || '';
+      if (title._) title = title._;
+      if (title) item.title = title;
+    }
+    if (entry.link && entry.link.length) {
+      item.link = utils.getLink(entry.link, 'alternate', 0);
+    }
+    if (entry.published && entry.published.length && entry.published[0].length) item.pubDate = new Date(entry.published[0]).toISOString();
+    if (!item.pubDate && entry.updated && entry.updated.length && entry.updated[0].length) item.pubDate = new Date(entry.updated[0]).toISOString();
+    if (entry.author && entry.author.length && entry.author[0].name && entry.author[0].name.length) item.author = entry.author[0].name[0];
+    if (entry.content && entry.content.length) {
+      item.content = utils.getContent(entry.content[0]);
+      item.contentSnippet = utils.getSnippet(item.content)
+    }
+    if (entry.id) {
+      item.id = entry.id[0];
+    }
+    this.setISODate(item);
+    return item;
   }
 
   buildRSS0_9(xmlObj) {
@@ -195,24 +200,29 @@ class Parser {
     }
     utils.copyFromXML(channel, feed, feedFields);
     items.forEach(xmlItem => {
-      let item = {};
-      utils.copyFromXML(xmlItem, item, itemFields);
-      if (xmlItem.enclosure) {
-        item.enclosure = xmlItem.enclosure[0].$;
-      }
-      if (xmlItem.description) {
-        item.content = utils.getContent(xmlItem.description[0]);
-        item.contentSnippet = utils.getSnippet(item.content);
-      }
-      if (xmlItem.guid) {
-        item.guid = xmlItem.guid[0];
-        if (item.guid._) item.guid = item.guid._;
-      }
-      if (xmlItem.category) item.categories = xmlItem.category;
-      this.setISODate(item);
+      let item = this.parseItemRss(xmlItem, itemFields);
       feed.items.push(item);
     });
     return feed;
+  }
+
+  parseItemRss(xmlItem, itemFields) {
+    let item = {};
+    utils.copyFromXML(xmlItem, item, itemFields);
+    if (xmlItem.enclosure) {
+      item.enclosure = xmlItem.enclosure[0].$;
+    }
+    if (xmlItem.description) {
+      item.content = utils.getContent(xmlItem.description[0]);
+      item.contentSnippet = utils.getSnippet(item.content);
+    }
+    if (xmlItem.guid) {
+      item.guid = xmlItem.guid[0];
+      if (item.guid._) item.guid = item.guid._;
+    }
+    if (xmlItem.category) item.categories = xmlItem.category;
+    this.setISODate(item);
+    return item;
   }
 
   /**


### PR DESCRIPTION
I working on extremely small blog engine @yurt-page and blog records are stored as a plain atom xml. Then they are fetched as a file and parsed on frontend. So instead of full atom feed I have only one entry. To parse it I need to get access to the low level entry parsing functionality but rss-parser exports only generic parseURL() method.
So I extracted the two additional methods parseItemAtom() and parseItemRss() and will use them directly. For me it's fine that they aren't exposed in typescript interface and I'm fine if they can be changed in future.
I would be thankful if you accept the PR to make my life easier.