### PR TITLE
[Typing] feeds.items is never null

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -51,7 +51,7 @@ declare namespace Parser {
     },
     link?: string;
     title?: string;
-    items?: (U & Item)[];
+    items: (U & Item)[];
     feedUrl?: string;
     description?: string;
     itunes?: {


### PR DESCRIPTION
Since feeds.items is always an array (empty if no items in feed), the typing should indicate it clearly.

Closes #177