### PR TITLE
Add property for iTunes categories with subcategories

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -254,11 +254,18 @@ class Parser {
       }
     }
 
-    if(channel['itunes:category']) {
-      channel['itunes:category'].forEach((category) => {
-        categories.push(category.$.text);
+    if (channel['itunes:category']) {
+      const categoriesWithSubs = channel['itunes:category'].map((category) => {
+        return {
+          name: category.$.text,
+          subs: category['itunes:category'] ?
+            category['itunes:category']
+              .map((subcategory) => ({ name: subcategory.$.text })) : null,
+        };
       });
-      feed.itunes.categories = categories;
+
+      feed.itunes.categories = categoriesWithSubs.map((category) => category.name);
+      feed.itunes.categoriesWithSubs = categoriesWithSubs;
     }
 
     if (channel['itunes:keywords']) {

--- a/test/output/giantbomb-podcast.json
+++ b/test/output/giantbomb-podcast.json
@@ -16816,6 +16816,32 @@
         "Technology",
         "Games & Hobbies"
       ],
+      "categoriesWithSubs": [
+        {
+          "name": "Games & Hobbies",
+          "subs": [
+            {
+              "name": "Video Games"
+            }
+          ]
+        },
+        {
+          "name": "Technology",
+          "subs": [
+            {
+              "name": "Gadgets"
+            }
+          ]
+        },
+        {
+          "name": "Games & Hobbies",
+          "subs": [
+            {
+              "name": "Other Games"
+            }
+          ]
+        }
+      ],
       "keywords": [
         "GiantBomb",
         " Giant Bomb",

--- a/test/output/itunes-category.json
+++ b/test/output/itunes-category.json
@@ -57,6 +57,20 @@
         "Society & Culture",
         "Games & Hobbies"
       ],
+      "categoriesWithSubs": [
+        {
+          "name": "Society & Culture",
+          "subs": null
+        },
+        {
+          "name": "Games & Hobbies",
+          "subs": [
+            {
+              "name": "Hobbies"
+            }
+          ]
+        }
+      ],
       "author": "Bryce Erwin, Bill Ticknor, Michelle O'Neill, Mike Monan, Aric Watson, Jennifer Albrecht, Lauren Hoban and Derek Chew",
       "subtitle": "Beer - Talk - Fun.  It's Happy Hour in Your Head!",
       "summary": "Order a beer, pull up a seat and join your friends at Taverncast for our patented un-scripted roundtable discussions, covering a wide range of topics with a unique wit and inviting style - all blended together, it's Happy Hour in Your Head!",

--- a/test/output/itunes-keywords-astext.json
+++ b/test/output/itunes-keywords-astext.json
@@ -692,6 +692,16 @@
       "categories": [
         "Music"
       ],
+      "categoriesWithSubs": [
+        {
+          "name": "Music",
+          "subs": [
+            {
+              "name": "Music Interviews"
+            }
+          ]
+        }
+      ],
       "keywords": [
         "Moderatoren"
       ],


### PR DESCRIPTION
This commit allows for accessing subcategories that are provided with the iTunes meta-data. This is a non-breaking change for the categories property.