### PR TITLE
Add parsing of pagination links for RSS v2.0

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -43,12 +43,21 @@ declare namespace Parser {
     enclosure?: Enclosure;
   }
 
+  export interface PaginationLinks {
+    self?: string;
+    first?: string;
+    next?: string;
+    last?: string;
+    prev?: string;
+  }
+
   export interface Output<U> {
     image?: {
       link?: string;
       url: string;
       title?: string;
     },
+    paginationLinks?: PaginationLinks;
     link?: string;
     title?: string;
     items: (U & Item)[];

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -195,6 +195,10 @@ class Parser {
       if (image.width) feed.image.width = image.width[0];
       if (image.height) feed.image.height = image.height[0];
     }
+    const paginationLinks = this.generatePaginationLinks(channel);
+    if (Object.keys(paginationLinks).length) {
+      feed.paginationLinks = paginationLinks;
+    }
     utils.copyFromXML(channel, feed, feedFields);
     feed.items = items.map(xmlItem => this.parseItemRss(xmlItem, itemFields));
     return feed;
@@ -308,6 +312,29 @@ class Parser {
         // Ignore bad date format
       }
     }
+  }
+
+  /**
+   * Generates a pagination object where the rel attribute is the key and href attribute is the value
+   *  { self: 'self-url', first: 'first-url', ...  }
+   *
+   * @access private
+   * @param {Object} channel parsed XML
+   * @returns {Object}
+   */
+  generatePaginationLinks(channel) {
+    if (!channel['atom:link']) {
+      return {};
+    }
+    const paginationRelAttributes = ['self', 'first', 'next', 'prev', 'last'];
+
+    return channel['atom:link'].reduce((paginationLinks, link) => {
+      if (!link.$ || !paginationRelAttributes.includes(link.$.rel)) {
+        return paginationLinks;
+      }
+      paginationLinks[link.$.rel] = link.$.href;
+      return paginationLinks;
+    }, {});
   }
 }
 

--- a/test/input/pagination-links.rss
+++ b/test/input/pagination-links.rss
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?><rss xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
+    <channel>
+		<title>New Show - With Episode Block</title>
+        <atom:link href="http://example.org/index.atom?page=3" rel="self" type="application/rss+xml"/>
+        <atom:link rel="first" href="http://example.org/index.atom"/>
+		<atom:link rel="next" href="http://example.org/index.atom?page=4"/>
+		<atom:link rel="prev" href="http://example.org/index.atom?page=2"/>
+        <atom:link rel="last" href="http://example.org/index.atom?page=5"/>
+        <link>https://example.test/shows/new-show-1</link>
+        <language>en-us</language>
+        <lastBuildDate>Tue, 31 Mar 2020 05:19:30 +0000</lastBuildDate>
+        <itunes:subtitle>New Show</itunes:subtitle>
+        <itunes:author>Steve Thompson</itunes:author>
+        <itunes:summary>New Show</itunes:summary>
+        <description><![CDATA[New Show]]></description>
+        <itunes:explicit>No</itunes:explicit>
+        <itunes:type>episodic</itunes:type>
+        <itunes:owner>
+            <itunes:name>Steve Thompson</itunes:name>
+            <itunes:email>steve.t@gmail.com</itunes:email>
+        </itunes:owner>
+        <itunes:image href="https://example.test/test-image.jpg"/>
+        <itunes:category text="Arts"/>
+        <image>
+            <url>https://example.test/test-image.jpg</url>
+            <title>New Show</title>
+            <link>https://example.test/shows/new-show-1</link>
+            <description>New Show</description>
+        </image>
+        <itunes:block>Yes</itunes:block>
+		<item>
+			<title>The First Episode</title>
+            <link>https://example.test/episode?id=283843</link>
+			<pubDate>Thu, 21 Jan 2021 18:58:00 +1100</pubDate>
+			<itunes:author>Steve Thompson</itunes:author>
+            <itunes:summary>The First Episode</itunes:summary>
+            <description><![CDATA[<div>The First Episode</div>]]></description>
+            <itunes:subtitle>The First Episode...</itunes:subtitle>
+			<itunes:image href="https://example.test/test-image.jpg"/>
+            <enclosure url="https://example.test/test-audio.mp3" length="38068096" type="audio/mpeg"/>
+            <itunes:duration>39:27</itunes:duration>
+			<guid isPermaLink="false">a6f22abe-be5c-4a37-8f4b-8be3d69b0235</guid>
+            <itunes:explicit>No</itunes:explicit>
+		</item>
+    </channel>
+</rss>

--- a/test/output/content-encoded.json
+++ b/test/output/content-encoded.json
@@ -134,6 +134,9 @@
       "url": "https://cdn-images-1.medium.com/proxy/1*TGH72Nnw24QL3iV9IOm4VA.png",
       "title": "Food in Invironment on Medium"
     },
+    "paginationLinks": {
+      "self": "https://medium.com/feed/invironment/tagged/food"
+    },
     "title": "Food in Invironment on Medium",
     "description": "Latest stories tagged with Food in Invironment on Medium",
     "webMaster": "yourfriends@medium.com",

--- a/test/output/giantbomb-podcast.json
+++ b/test/output/giantbomb-podcast.json
@@ -16800,6 +16800,9 @@
       "width": "144",
       "height": "144"
     },
+    "paginationLinks": {
+      "self": "https://www.giantbomb.com"
+    },
     "title": "Giant Bombcast",
     "description": "Giant Bomb discusses the latest video game news and new releases, taste-test questionable beverages, and get wildly off-topic in this weekly podcast.",
     "link": "https://www.giantbomb.com",

--- a/test/output/itunes-keywords-array.json
+++ b/test/output/itunes-keywords-array.json
@@ -29,6 +29,9 @@
       "url": "https://www.swr.de/swr2/programm/Podcastbild-SWR2-Impuls,1564741489275,swr2-impuls-podcast-104~_v-16x9@2dS_-6be50a9c75559ca1aaf1d0b25bae287afdcd877a.jpg",
       "title": "SWR2 Impuls - Wissen aktuell"
     },
+    "paginationLinks": {
+      "self": "https://www.swr.de/~podcast/swr2/programm/SWR2-Wissen-Impuls-Podcast,swr2-impuls-podcast-100.xml"
+    },
     "title": "SWR2 Impuls - Wissen aktuell",
     "description": "Neues aus Wissenschaft, Medizin, Umwelt und Bildung. ",
     "pubDate": "Wed, 9 Oct 2019 16:39:00 +0200",

--- a/test/output/itunes-keywords-astext.json
+++ b/test/output/itunes-keywords-astext.json
@@ -677,6 +677,9 @@
       "url": "https://www.dasding.de/podcasts/1590648935875,endorphine-fuer-delfine-thumbnail-100~_logo-dasding@2dlogo@2d100_v-16x9@2dS_-278f7c321da1eb2d03730e27f1e14a4056a0d1fb.jpg",
       "title": "Endorphine für Delfine"
     },
+    "paginationLinks": {
+      "self": "https://www.dasding.de/~podcast/podcasts/endorphine-fuer-delfine-100.xml"
+    },
     "title": "Endorphine für Delfine",
     "description": "Auf einer Skala von 1 bis glücklicher Delfin – wie geil ist es wirklich, dauernd Stars zu treffen und ihnen Fragen zu stellen? Walerija und Johannes nehmen dich mit in ihre Welt vor und hinter der Kamera. Auf dem YouTube-Kanal von DASDING sprechen sie in ihren Formaten Scratched und Song-Tindern mit den Billie Eilishs, Kontra Ks und Jujus dieser Welt. Hier im Podcast gibt es alles zu hören, was die Kamera nicht sehen konnte.",
     "pubDate": "Tue, 29 Sep 2020 13:14:21 +0200",

--- a/test/output/narro.json
+++ b/test/output/narro.json
@@ -27,6 +27,9 @@
       }
     ],
     "feedUrl": "http://on.narro.co/f",
+    "paginationLinks": {
+      "self": "http://on.narro.co/f"
+    },
     "title": "foobar on Narro",
     "description": "foobar uses Narro to create a podcast of articles transcribed to audio.",
     "pubDate": "Fri, 08 Jul 2016 13:40:00 UTC",

--- a/test/output/pagination-links.json
+++ b/test/output/pagination-links.json
@@ -1,0 +1,66 @@
+{
+  "feed": {
+    "items": [
+      {
+        "content": "<div>The First Episode</div>",
+        "contentSnippet": "The First Episode",
+        "enclosure": {
+          "length": "38068096",
+          "type": "audio/mpeg",
+          "url": "https://example.test/test-audio.mp3"
+        },
+        "guid": "a6f22abe-be5c-4a37-8f4b-8be3d69b0235",
+        "isoDate": "2021-01-21T07:58:00.000Z",
+        "itunes": {
+          "author": "Steve Thompson",
+          "duration": "39:27",
+          "explicit": "No",
+          "image": "https://example.test/test-image.jpg",
+          "subtitle": "The First Episode...",
+          "summary": "The First Episode"
+        },
+        "link": "https://example.test/episode?id=283843",
+        "pubDate": "Thu, 21 Jan 2021 18:58:00 +1100",
+        "title": "The First Episode"
+      }
+    ],
+    "feedUrl": "http://example.org/index.atom?page=3",
+    "image": {
+      "link": "https://example.test/shows/new-show-1",
+      "url": "https://example.test/test-image.jpg",
+      "title": "New Show"
+    },
+    "paginationLinks": {
+      "self": "http://example.org/index.atom?page=3",
+      "first": "http://example.org/index.atom",
+      "next": "http://example.org/index.atom?page=4",
+      "prev": "http://example.org/index.atom?page=2",
+      "last": "http://example.org/index.atom?page=5"
+    },
+    "title": "New Show - With Episode Block",
+    "description": "New Show",
+    "link": "https://example.test/shows/new-show-1",
+    "language": "en-us",
+    "lastBuildDate": "Tue, 31 Mar 2020 05:19:30 +0000",
+    "itunes": {
+      "owner": {
+        "name": "Steve Thompson",
+        "email": "steve.t@gmail.com"
+      },
+      "image": "https://example.test/test-image.jpg",
+      "categories": [
+        "Arts"
+      ],
+      "categoriesWithSubs": [
+        {
+          "name": "Arts",
+          "subs": null
+        }
+      ],
+      "author": "Steve Thompson",
+      "subtitle": "New Show",
+      "summary": "New Show",
+      "explicit": "No"
+    }
+  }
+}

--- a/test/output/reddit-atom.json
+++ b/test/output/reddit-atom.json
@@ -308,6 +308,9 @@
       "url": "https://www.redditstatic.com/reddit.com.header.png",
       "title": "reddit: the front page of the internet"
     },
+    "paginationLinks": {
+      "self": "https://www.reddit.com/.rss"
+    },
     "title": "reddit: the front page of the internet",
     "description": "",
     "link": "https://www.reddit.com/"

--- a/test/output/reddit.json
+++ b/test/output/reddit.json
@@ -308,6 +308,9 @@
       "url": "https://www.redditstatic.com/reddit.com.header.png",
       "title": "reddit: the front page of the internet"
     },
+    "paginationLinks": {
+      "self": "https://www.reddit.com/.rss"
+    },
     "title": "reddit: the front page of the internet",
     "description": "",
     "link": "https://www.reddit.com/"

--- a/test/parser.js
+++ b/test/parser.js
@@ -276,4 +276,8 @@ describe('Parser', function() {
   it('should parse content:encoded', function(done) {
     testParseForFile('content-encoded', 'rss', done);
   });
+
+  it('should parse atom:link pagination links', function (done) {
+    testParseForFile('pagination-links', 'rss', done);
+  });
 })


### PR DESCRIPTION
Hello,

According to the [RF5005 Web Feed Specification Section 3](https://tools.ietf.org/html/rfc5005#section-3) a web feed can be paginated. The [Appendix B](https://tools.ietf.org/html/rfc5005#appendix-B) of the same document explains how they can be implemented in RSS Feeds v2.0 which uses a tag like `<atom:link rel="self" href="url">`. Therefore, I would like to add this functionality to the package.