### PR TITLE
Allow any header names in ParserOptions TypeScript interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,7 +12,7 @@ declare namespace Parser {
   export interface ParserOptions<T, U> {
     readonly xml2js?: Options;
     readonly requestOptions?: RequestOptions;
-    readonly headers?: { [key: string]: string; };
+    readonly headers?: Record<string, string>;
     readonly defaultRSS?: number;
     readonly maxRedirects?: number;
     readonly customFields?: CustomFields<T, U>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,11 +2,6 @@ import { Options } from 'xml2js';
 import { RequestOptions } from 'https';
 
 declare namespace Parser {
-  export interface Headers {
-    readonly Accept?: string;
-    readonly 'User-Agent'?: string;
-  }
-
   type CustomFieldItem<U> = keyof U | { keepArray: boolean }
     
   export interface CustomFields<T, U> {
@@ -17,7 +12,7 @@ declare namespace Parser {
   export interface ParserOptions<T, U> {
     readonly xml2js?: Options;
     readonly requestOptions?: RequestOptions;
-    readonly headers?: Headers;
+    readonly headers?: { [key: string]: string; };
     readonly defaultRSS?: number;
     readonly maxRedirects?: number;
     readonly customFields?: CustomFields<T, U>;


### PR DESCRIPTION
Programs should be allowed to use any header name (standard or non-standard) when requesting the feed, I have updated the TypeScript definitions to reflect this. The new definition allows an object with any strings as keys and any strings as values (see https://stackoverflow.com/a/51161730).