### PR TITLE
add `rdf:about` field to item on `parseItemRss`

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -221,6 +221,7 @@ class Parser {
       item.guid = xmlItem.guid[0];
       if (item.guid._) item.guid = item.guid._;
     }
+    item['rdf:abount'] = xmlItem.$['rdf:about']
     if (xmlItem.category) item.categories = xmlItem.category;
     this.setISODate(item);
     return item;

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -221,7 +221,7 @@ class Parser {
       item.guid = xmlItem.guid[0];
       if (item.guid._) item.guid = item.guid._;
     }
-    item['rdf:abount'] = xmlItem.$['rdf:about']
+    item['rdf:about'] = xmlItem.$['rdf:about']
     if (xmlItem.category) item.categories = xmlItem.category;
     this.setISODate(item);
     return item;


### PR DESCRIPTION
FIX: #202 

## About

I want to access `rdf:about` field of item.

## What to change

add `rdf:about` field to item.

## How to check

[![Image from Gyazo](https://i.gyazo.com/8d0b97de58b0741c1e3aa261e512f1cb.png)](https://gyazo.com/8d0b97de58b0741c1e3aa261e512f1cb)

## Specification of RSS 1.0

https://validator.w3.org/feed/docs/rss1.html#s5.5
> {item_uri} should be identical to the value of the <link> sub-element of the <item> element, if possible.
> Required Attribute(s): rdf:about

`rdf:about` attribute of `item` is required by RSS 1.0 spec.
And `rdf:about` is not must to same value of `link` element.
