### PR TITLE
Don't change User-Agent to prevent preflight request.

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -8,7 +8,6 @@ const fields = require('./fields');
 const utils = require('./utils');
 
 const DEFAULT_HEADERS = {
-  'User-Agent': 'rss-parser',
   'Accept': 'application/rss+xml',
 }
 const DEFAULT_MAX_REDIRECTS = 5;


### PR DESCRIPTION
Hi, I found a weired issue.
rss-parser does not fetch feed that is hosted github.io with Firefox, but no problem with Chrome.
github.io responds  `Access-Control-Allow-Origin: *` as expected.
The cause was that Firefox was sending a CORS preflight request.
There are several conditions for sending a preflight request, one of which is  User-Agent changing.
https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#examples_of_access_control_scenarios

I think many people will be bothered by this issue, so
I recommend not to set User-Agent by default.