### PR TITLE
Build fix related to 'rdf:about'

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [14.x, 16.x, 18.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -221,7 +221,9 @@ class Parser {
       item.guid = xmlItem.guid[0];
       if (item.guid._) item.guid = item.guid._;
     }
-    item['rdf:about'] = xmlItem.$['rdf:about']
+    if (xmlItem.$ && xmlItem.$['rdf:about']) {
+      item['rdf:about'] = xmlItem.$['rdf:about']
+    }
     if (xmlItem.category) item.categories = xmlItem.category;
     this.setISODate(item);
     return item;

--- a/test/output/craigslist.json
+++ b/test/output/craigslist.json
@@ -11,6 +11,7 @@
         "dc:date": "2017-06-21T10:33:10-07:00",
         "content": "Updated 3+ Bedroom, 2.5 Bath, Victorian home. Beautiful original oak hardwoods, high ceilings with crown molding, stainless steel appliances, large sunny deck directly next to the kitchen for grilling and entertaining. Radiant floor heating throughou [...]",
         "contentSnippet": "Updated 3+ Bedroom, 2.5 Bath, Victorian home. Beautiful original oak hardwoods, high ceilings with crown molding, stainless steel appliances, large sunny deck directly next to the kitchen for grilling and entertaining. Radiant floor heating throughou [...]",
+        "rdf:about": "http://sfbay.craigslist.org/eby/apa/6186664607.html",
         "isoDate": "2017-06-21T17:33:10.000Z"
       },
       {
@@ -23,6 +24,7 @@
         "dc:date": "2017-06-21T10:33:00-07:00",
         "content": "100 Terra Vista #2, San Francisco, CA 94115 This Spacious beautifully remodeled 1 Br unit in 4 Plex - Unit is vacant and available for Immediate Occupancy \nApartment Features \n1 Bedroom, 1 Bath \nLoads of Natural Light and Large Windows \nModern kitche [...]",
         "contentSnippet": "100 Terra Vista #2, San Francisco, CA 94115 This Spacious beautifully remodeled 1 Br unit in 4 Plex - Unit is vacant and available for Immediate Occupancy \nApartment Features \n1 Bedroom, 1 Bath \nLoads of Natural Light and Large Windows \nModern kitche [...]",
+        "rdf:about": "http://sfbay.craigslist.org/sfc/apa/6156068288.html",
         "isoDate": "2017-06-21T17:33:00.000Z"
       },
       {
@@ -35,6 +37,7 @@
         "dc:date": "2017-06-21T10:32:59-07:00",
         "content": "CONTACT ME~ ASK FOR FALIZ!!! \nInquire about other units available as well. \nWe are a 560 apartment complex located in a residential are in Vallejo/Benicia area. We are located near Blue Rock Springs park and Blue Rock Golf course. \n-Washer/Dryer in u [...]",
         "contentSnippet": "CONTACT ME~ ASK FOR FALIZ!!! \nInquire about other units available as well. \nWe are a 560 apartment complex located in a residential are in Vallejo/Benicia area. We are located near Blue Rock Springs park and Blue Rock Golf course. \n-Washer/Dryer in u [...]",
+        "rdf:about": "http://sfbay.craigslist.org/eby/apa/6186664268.html",
         "isoDate": "2017-06-21T17:32:59.000Z"
       },
       {
@@ -47,6 +50,7 @@
         "dc:date": "2017-06-21T10:32:58-07:00",
         "content": "CONTACT INFO Mtn. View Rental Center \n <a href=\"/fb/sfo/apa/6178016537\" class=\"showcontact\" title=\"click to show contact info\">show contact info</a>\nRemodeled 1Bedroom 1Bath Apartment Home at The Arbors $2095 - $2,095 per month 2220 California Street, Mtn. View, CA 94040 FEATURES Bedrooms:&nbsp; 1 Bathrooms:&nbsp; 1 Located on Floor #:&nbsp; 2 Flo [...]",
         "contentSnippet": "CONTACT INFO Mtn. View Rental Center \n show contact info\nRemodeled 1Bedroom 1Bath Apartment Home at The Arbors $2095 - $2,095 per month 2220 California Street, Mtn. View, CA 94040 FEATURES Bedrooms:  1 Bathrooms:  1 Located on Floor #:  2 Flo [...]",
+        "rdf:about": "http://sfbay.craigslist.org/pen/apa/6178016537.html",
         "isoDate": "2017-06-21T17:32:58.000Z"
       },
       {
@@ -59,6 +63,7 @@
         "dc:date": "2017-06-21T10:32:54-07:00",
         "content": "\n <a href=\"/fb/sfo/apa/6186664134\" class=\"showcontact\" title=\"click to show contact info\">show contact info</a>\n\n123 N. El Camino Real \nOur community has been recently renovated as have many of our apartment interiors. Including custom paint, new appliances, carpet, and lighting. We have convenient parking and additional guest parking, on-site lau [...]",
         "contentSnippet": "show contact info\n\n123 N. El Camino Real \nOur community has been recently renovated as have many of our apartment interiors. Including custom paint, new appliances, carpet, and lighting. We have convenient parking and additional guest parking, on-site lau [...]",
+        "rdf:about": "http://sfbay.craigslist.org/pen/apa/6186664134.html",
         "isoDate": "2017-06-21T17:32:54.000Z"
       },
       {
@@ -71,6 +76,7 @@
         "dc:date": "2017-06-21T10:32:48-07:00",
         "content": "Home is available for showing. Please reply by email to schedule an appointment. \nsingle family 4bedroom 2 bathroom home in Dublin. single story, available for immediate rent. Upgraded kitchen with Granite counters, Stainless Steel Appliances, Gas co [...]",
         "contentSnippet": "Home is available for showing. Please reply by email to schedule an appointment. \nsingle family 4bedroom 2 bathroom home in Dublin. single story, available for immediate rent. Upgraded kitchen with Granite counters, Stainless Steel Appliances, Gas co [...]",
+        "rdf:about": "http://sfbay.craigslist.org/eby/apa/6186643068.html",
         "isoDate": "2017-06-21T17:32:48.000Z"
       },
       {
@@ -83,6 +89,7 @@
         "dc:date": "2017-06-21T10:32:41-07:00",
         "content": "Beautiful floor plan; Large walk-in closet and more. \nWe are located close to the 580 freeway; Springtown golf course; library and not very far from local shopping. Visit the local restaurants and get a variety to please the palate. Bingo; billiards; [...]",
         "contentSnippet": "Beautiful floor plan; Large walk-in closet and more. \nWe are located close to the 580 freeway; Springtown golf course; library and not very far from local shopping. Visit the local restaurants and get a variety to please the palate. Bingo; billiards; [...]",
+        "rdf:about": "http://sfbay.craigslist.org/eby/apa/6186663734.html",
         "isoDate": "2017-06-21T17:32:41.000Z"
       },
       {
@@ -95,6 +102,7 @@
         "dc:date": "2017-06-21T10:32:32-07:00",
         "content": "Available for July 1st occupancy is a cute 1 bedroom, 1 bathroom detached house/cottage located at 368 Page Street in San Jose. This is the middle house on a large parcel of land with two other detached houses. \nThe Cottage features: \n- A large bedro [...]",
         "contentSnippet": "Available for July 1st occupancy is a cute 1 bedroom, 1 bathroom detached house/cottage located at 368 Page Street in San Jose. This is the middle house on a large parcel of land with two other detached houses. \nThe Cottage features: \n- A large bedro [...]",
+        "rdf:about": "http://sfbay.craigslist.org/sby/apa/6186663427.html",
         "isoDate": "2017-06-21T17:32:32.000Z"
       },
       {
@@ -107,6 +115,7 @@
         "dc:date": "2017-06-21T10:32:28-07:00",
         "content": "We are looking for renters for the lower level of our home. It's a newly remodeled, completely separate, 2 bedroom apartment. \nWe are only an 8-10 minute walk from Fruitvale BART in the lovely Fruitvale district and blocks away from great restaurants [...]",
         "contentSnippet": "We are looking for renters for the lower level of our home. It's a newly remodeled, completely separate, 2 bedroom apartment. \nWe are only an 8-10 minute walk from Fruitvale BART in the lovely Fruitvale district and blocks away from great restaurants [...]",
+        "rdf:about": "http://sfbay.craigslist.org/eby/apa/6181466671.html",
         "isoDate": "2017-06-21T17:32:28.000Z"
       },
       {
@@ -119,6 +128,7 @@
         "dc:date": "2017-06-21T10:32:27-07:00",
         "content": "For Lease:Large Studio Apt,Full size Kitchen,Walk-in Closet,2-Room Bath Area.(Water,Garbage and Gas is Paid)Laundry rooms on site,Underground Parking,Elevators,Heated Pool.We are located near Shopping and Transportation also near Edgewood Park.By App [...]",
         "contentSnippet": "For Lease:Large Studio Apt,Full size Kitchen,Walk-in Closet,2-Room Bath Area.(Water,Garbage and Gas is Paid)Laundry rooms on site,Underground Parking,Elevators,Heated Pool.We are located near Shopping and Transportation also near Edgewood Park.By App [...]",
+        "rdf:about": "http://sfbay.craigslist.org/pen/apa/6151867421.html",
         "isoDate": "2017-06-21T17:32:27.000Z"
       },
       {
@@ -131,6 +141,7 @@
         "dc:date": "2017-06-21T10:32:17-07:00",
         "content": "Contact info: Nancy Barrera | \n <a href=\"/fb/sfo/apa/6175713069\" class=\"showcontact\" title=\"click to show contact info\">show contact info</a>\n| \n <a href=\"/fb/sfo/apa/6175713069\" class=\"showcontact\" title=\"click to show contact info\">show contact info</a>\n Carriage House Apartments 38725 Lexington St , Fremont, CA 94536 KEY FEATURES Year Built: 1972 Sq Footage: 828 sqft. Bedrooms: 1 Bed Bathrooms: 1 Bath Parking: 1 Carport Leas [...]",
         "contentSnippet": "Contact info: Nancy Barrera | \n show contact info\n| \n show contact info\n Carriage House Apartments 38725 Lexington St , Fremont, CA 94536 KEY FEATURES Year Built: 1972 Sq Footage: 828 sqft. Bedrooms: 1 Bed Bathrooms: 1 Bath Parking: 1 Carport Leas [...]",
+        "rdf:about": "http://sfbay.craigslist.org/eby/apa/6175713069.html",
         "isoDate": "2017-06-21T17:32:17.000Z"
       },
       {
@@ -143,6 +154,7 @@
         "dc:date": "2017-06-21T10:32:09-07:00",
         "content": "$1,850 per month 1 bedrooms, 1 full baths,\n0 half baths, 625 square feet\nAlma Blazevic | NAS Property Group | \n <a href=\"/fb/sfo/apa/6186662875\" class=\"showcontact\" title=\"click to show contact info\">show contact info</a>\n1125 Ranchero Way, San Jose, CA This Spacious, 1 Bd Unit with A/C Available Ju 30th to Move In!! This Unit Features spacious  [...]",
         "contentSnippet": "$1,850 per month 1 bedrooms, 1 full baths,\n0 half baths, 625 square feet\nAlma Blazevic | NAS Property Group | \n show contact info\n1125 Ranchero Way, San Jose, CA This Spacious, 1 Bd Unit with A/C Available Ju 30th to Move In!! This Unit Features spacious  [...]",
+        "rdf:about": "http://sfbay.craigslist.org/sby/apa/6186662875.html",
         "isoDate": "2017-06-21T17:32:09.000Z"
       },
       {
@@ -155,6 +167,7 @@
         "dc:date": "2017-06-21T10:32:07-07:00",
         "content": "Welcome to lovely Carriage House Apartments. Our community currently has different floor plans available. All of our units are equipped with a long list of features, including wall to wall carpet, fully equipped kitchens with dishwasher, stove and re [...]",
         "contentSnippet": "Welcome to lovely Carriage House Apartments. Our community currently has different floor plans available. All of our units are equipped with a long list of features, including wall to wall carpet, fully equipped kitchens with dishwasher, stove and re [...]",
+        "rdf:about": "http://sfbay.craigslist.org/eby/apa/6175706074.html",
         "isoDate": "2017-06-21T17:32:07.000Z"
       },
       {
@@ -167,6 +180,7 @@
         "dc:date": "2017-06-21T10:31:58-07:00",
         "content": "Contact info: Nancy Barrera | \n <a href=\"/fb/sfo/apa/6179687565\" class=\"showcontact\" title=\"click to show contact info\">show contact info</a>\n| \n <a href=\"/fb/sfo/apa/6179687565\" class=\"showcontact\" title=\"click to show contact info\">show contact info</a>\n Carriage House Apartments 38725 Lexington St, Fremont, CA 94536 $2,550/mo KEY FEATURES Bedrooms: 2 Beds Bathrooms: 2 Baths Lease Duration: 1 Year Deposit: $800 Pets Policy: C [...]",
         "contentSnippet": "Contact info: Nancy Barrera | \n show contact info\n| \n show contact info\n Carriage House Apartments 38725 Lexington St, Fremont, CA 94536 $2,550/mo KEY FEATURES Bedrooms: 2 Beds Bathrooms: 2 Baths Lease Duration: 1 Year Deposit: $800 Pets Policy: C [...]",
+        "rdf:about": "http://sfbay.craigslist.org/eby/apa/6179687565.html",
         "isoDate": "2017-06-21T17:31:58.000Z"
       },
       {
@@ -179,6 +193,7 @@
         "dc:date": "2017-06-21T10:31:47-07:00",
         "content": "The Brookdale Apartments, managed by On-site Team \n4400 Albany Dr. \nSan Jose, CA 95129 \n\n <a href=\"/fb/sfo/apa/6176525357\" class=\"showcontact\" title=\"click to show contact info\">show contact info</a>\n\nIdeally located in San Jose on the Cupertino border and in the excellent Cupertino school district, Easy access to 280, 880 and Hwy 17. \nTwo large b [...]",
         "contentSnippet": "The Brookdale Apartments, managed by On-site Team \n4400 Albany Dr. \nSan Jose, CA 95129 \n\n show contact info\n\nIdeally located in San Jose on the Cupertino border and in the excellent Cupertino school district, Easy access to 280, 880 and Hwy 17. \nTwo large b [...]",
+        "rdf:about": "http://sfbay.craigslist.org/sby/apa/6176525357.html",
         "isoDate": "2017-06-21T17:31:47.000Z"
       },
       {
@@ -191,6 +206,7 @@
         "dc:date": "2017-06-21T10:31:44-07:00",
         "content": "Please contact Ma Properties at \n <a href=\"/fb/sfo/apa/6181392861\" class=\"showcontact\" title=\"click to show contact info\">show contact info</a>\nif you wish to schedule a viewing appointment. \nLocated in a quiet community with beautiful foliage. Complex includes swimming pool for tenants' enjoyment. \n2 Bedroom / 2 Bathroom \n1003 Bay View Farm Rd.,  [...]",
         "contentSnippet": "Please contact Ma Properties at \n show contact info\nif you wish to schedule a viewing appointment. \nLocated in a quiet community with beautiful foliage. Complex includes swimming pool for tenants' enjoyment. \n2 Bedroom / 2 Bathroom \n1003 Bay View Farm Rd.,  [...]",
+        "rdf:about": "http://sfbay.craigslist.org/eby/apa/6181392861.html",
         "isoDate": "2017-06-21T17:31:44.000Z"
       },
       {
@@ -203,6 +219,7 @@
         "dc:date": "2017-06-21T10:31:40-07:00",
         "content": "Please contact Ma Properties at \n <a href=\"/fb/sfo/apa/6170765620\" class=\"showcontact\" title=\"click to show contact info\">show contact info</a>\nif you wish to schedule a viewing appointment. \nStudio Apartment \n418- 41st Street, Oakland 94609 \nAvailable June 22, 2017 \nTerms: \n$1750 rent \n$1950 fully refundable security deposit \nParking: $130/month  [...]",
         "contentSnippet": "Please contact Ma Properties at \n show contact info\nif you wish to schedule a viewing appointment. \nStudio Apartment \n418- 41st Street, Oakland 94609 \nAvailable June 22, 2017 \nTerms: \n$1750 rent \n$1950 fully refundable security deposit \nParking: $130/month  [...]",
+        "rdf:about": "http://sfbay.craigslist.org/eby/apa/6170765620.html",
         "isoDate": "2017-06-21T17:31:40.000Z"
       },
       {
@@ -215,6 +232,7 @@
         "dc:date": "2017-06-21T10:31:36-07:00",
         "content": "Please contact Ma Properties at \n <a href=\"/fb/sfo/apa/6170826005\" class=\"showcontact\" title=\"click to show contact info\">show contact info</a>\nif you wish to schedule a viewing appointment. \nStudio / 1 Bathroom Apartment \n353 Euclid Ave., Oakland, 94610 \nAvailable June 22, 2017 \nTerms: \n$1700 rent \n$1900 fully refundable security deposit \nParking [...]",
         "contentSnippet": "Please contact Ma Properties at \n show contact info\nif you wish to schedule a viewing appointment. \nStudio / 1 Bathroom Apartment \n353 Euclid Ave., Oakland, 94610 \nAvailable June 22, 2017 \nTerms: \n$1700 rent \n$1900 fully refundable security deposit \nParking [...]",
+        "rdf:about": "http://sfbay.craigslist.org/eby/apa/6170826005.html",
         "isoDate": "2017-06-21T17:31:36.000Z"
       },
       {
@@ -227,6 +245,7 @@
         "dc:date": "2017-06-21T10:31:34-07:00",
         "content": "Alamo is a very private and peaceful area between Danville and Walnut Creek if you don't know it. \nThe house is located within 5-10 minutes of walking distance to Round Hill Country Club, a peaceful neighborhood with a beautiful environment for weeke [...]",
         "contentSnippet": "Alamo is a very private and peaceful area between Danville and Walnut Creek if you don't know it. \nThe house is located within 5-10 minutes of walking distance to Round Hill Country Club, a peaceful neighborhood with a beautiful environment for weeke [...]",
+        "rdf:about": "http://sfbay.craigslist.org/eby/apa/6186661838.html",
         "isoDate": "2017-06-21T17:31:34.000Z"
       },
       {
@@ -239,6 +258,7 @@
         "dc:date": "2017-06-21T10:31:32-07:00",
         "content": "Please contact Ma Properties at \n <a href=\"/fb/sfo/apa/6170826650\" class=\"showcontact\" title=\"click to show contact info\">show contact info</a>\nif you wish to schedule a viewing appointment. \nStudio Apartment \n418- 41st Street, Oakland 94609 \nAvailable June 14, 2017 \nTerms: \n$1750 rent \n$1950 fully refundable security deposit \nParking: $130/month  [...]",
         "contentSnippet": "Please contact Ma Properties at \n show contact info\nif you wish to schedule a viewing appointment. \nStudio Apartment \n418- 41st Street, Oakland 94609 \nAvailable June 14, 2017 \nTerms: \n$1750 rent \n$1950 fully refundable security deposit \nParking: $130/month  [...]",
+        "rdf:about": "http://sfbay.craigslist.org/eby/apa/6170826650.html",
         "isoDate": "2017-06-21T17:31:32.000Z"
       },
       {
@@ -251,6 +271,7 @@
         "dc:date": "2017-06-21T10:31:27-07:00",
         "content": "Please contact Ma Properties at \n <a href=\"/fb/sfo/apa/6170829613\" class=\"showcontact\" title=\"click to show contact info\">show contact info</a>\nif you wish to make a viewing appointment. \nBright, spacious unit in an AMAZING lakefront location. Easy access to BART and local amenities. \n1 Bedroom / 1 Bathroom Apartment \n1445 Lakeside Dr. \nOakland, C [...]",
         "contentSnippet": "Please contact Ma Properties at \n show contact info\nif you wish to make a viewing appointment. \nBright, spacious unit in an AMAZING lakefront location. Easy access to BART and local amenities. \n1 Bedroom / 1 Bathroom Apartment \n1445 Lakeside Dr. \nOakland, C [...]",
+        "rdf:about": "http://sfbay.craigslist.org/eby/apa/6170829613.html",
         "isoDate": "2017-06-21T17:31:27.000Z"
       },
       {
@@ -263,6 +284,7 @@
         "dc:date": "2017-06-21T10:31:27-07:00",
         "content": "Beautiful Natural Lighting 2 br 1 ba with 1 parking space\n501 S Fremont #3, San Mateo \nThis Spacious 2-bedroom 1 bath is ideally located in the west hills of San Mateo near Crystal Springs between highway 92 and 280. Beautiful running, walking and bi [...]",
         "contentSnippet": "Beautiful Natural Lighting 2 br 1 ba with 1 parking space\n501 S Fremont #3, San Mateo \nThis Spacious 2-bedroom 1 bath is ideally located in the west hills of San Mateo near Crystal Springs between highway 92 and 280. Beautiful running, walking and bi [...]",
+        "rdf:about": "http://sfbay.craigslist.org/pen/apa/6177358587.html",
         "isoDate": "2017-06-21T17:31:27.000Z"
       },
       {
@@ -275,6 +297,7 @@
         "dc:date": "2017-06-21T10:31:26-07:00",
         "content": "Ironwood http://liveatironwoodapts.com/su/pq5p Surrounded by rolling green hills and vineyards, Ironwood Apartments is a great place to call home. This 2Bd/1Ba apartment home has a washer/dryer in the home and two spacious bedrooms. Relax after a lon [...]",
         "contentSnippet": "Ironwood http://liveatironwoodapts.com/su/pq5p Surrounded by rolling green hills and vineyards, Ironwood Apartments is a great place to call home. This 2Bd/1Ba apartment home has a washer/dryer in the home and two spacious bedrooms. Relax after a lon [...]",
+        "rdf:about": "http://sfbay.craigslist.org/eby/apa/6174129422.html",
         "isoDate": "2017-06-21T17:31:26.000Z"
       },
       {
@@ -287,6 +310,7 @@
         "dc:date": "2017-06-21T10:31:23-07:00",
         "content": "Please contact Ma Properties at \n <a href=\"/fb/sfo/apa/6173868358\" class=\"showcontact\" title=\"click to show contact info\">show contact info</a>\nif you wish to schedule a viewing appointment. \n1 Bedroom / 1 Bathroom Apartment \n1514 Jackson St., Oakland, 94612 \nAvailable July 8, 2017 \nTerms: \n$2100/month \n$2300 fully refundable security deposit \nPar [...]",
         "contentSnippet": "Please contact Ma Properties at \n show contact info\nif you wish to schedule a viewing appointment. \n1 Bedroom / 1 Bathroom Apartment \n1514 Jackson St., Oakland, 94612 \nAvailable July 8, 2017 \nTerms: \n$2100/month \n$2300 fully refundable security deposit \nPar [...]",
+        "rdf:about": "http://sfbay.craigslist.org/eby/apa/6173868358.html",
         "isoDate": "2017-06-21T17:31:23.000Z"
       },
       {
@@ -299,6 +323,7 @@
         "dc:date": "2017-06-21T10:31:19-07:00",
         "content": "If you are interested in scheduling a viewing appointment, please contact Ma Properties at \n <a href=\"/fb/sfo/apa/6170845890\" class=\"showcontact\" title=\"click to show contact info\">show contact info</a>\n \n1 Bedroom/1Bathroom \n601 Brooklyn Ave. \nOakland, California 94606 \nAvailable Now \nTerms: \n$1950 rent \n$2150 fully refundable security deposit \nP [...]",
         "contentSnippet": "If you are interested in scheduling a viewing appointment, please contact Ma Properties at \n show contact info\n \n1 Bedroom/1Bathroom \n601 Brooklyn Ave. \nOakland, California 94606 \nAvailable Now \nTerms: \n$1950 rent \n$2150 fully refundable security deposit \nP [...]",
+        "rdf:about": "http://sfbay.craigslist.org/eby/apa/6170845890.html",
         "isoDate": "2017-06-21T17:31:19.000Z"
       }
     ],

--- a/test/output/pagination-links.json
+++ b/test/output/pagination-links.json
@@ -2,26 +2,26 @@
   "feed": {
     "items": [
       {
+        "title": "The First Episode",
+        "link": "https://example.test/episode?id=283843",
+        "pubDate": "Thu, 21 Jan 2021 18:58:00 +1100",
+        "enclosure": {
+          "url": "https://example.test/test-audio.mp3",
+          "length": "38068096",
+          "type": "audio/mpeg"
+        },
         "content": "<div>The First Episode</div>",
         "contentSnippet": "The First Episode",
-        "enclosure": {
-          "length": "38068096",
-          "type": "audio/mpeg",
-          "url": "https://example.test/test-audio.mp3"
-        },
         "guid": "a6f22abe-be5c-4a37-8f4b-8be3d69b0235",
         "isoDate": "2021-01-21T07:58:00.000Z",
         "itunes": {
           "author": "Steve Thompson",
-          "duration": "39:27",
-          "explicit": "No",
-          "image": "https://example.test/test-image.jpg",
           "subtitle": "The First Episode...",
-          "summary": "The First Episode"
-        },
-        "link": "https://example.test/episode?id=283843",
-        "pubDate": "Thu, 21 Jan 2021 18:58:00 +1100",
-        "title": "The First Episode"
+          "summary": "The First Episode",
+          "explicit": "No",
+          "duration": "39:27",
+          "image": "https://example.test/test-image.jpg"
+        }
       }
     ],
     "feedUrl": "http://example.org/index.atom?page=3",

--- a/test/output/rss-1.json
+++ b/test/output/rss-1.json
@@ -10,6 +10,7 @@
         "dc:date": "2017-06-15T10:29:47-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6343/1134-a?rss=1",
         "isoDate": "2017-06-15T17:29:47.000Z"
       },
       {
@@ -21,6 +22,7 @@
         "dc:date": "2017-06-15T10:29:47-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6343/1134-b?rss=1",
         "isoDate": "2017-06-15T17:29:47.000Z"
       },
       {
@@ -32,6 +34,7 @@
         "dc:date": "2017-06-15T10:29:47-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6343/1134-c?rss=1",
         "isoDate": "2017-06-15T17:29:47.000Z"
       },
       {
@@ -43,6 +46,7 @@
         "dc:date": "2017-06-15T10:29:47-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6343/1134-d?rss=1",
         "isoDate": "2017-06-15T17:29:47.000Z"
       },
       {
@@ -54,6 +58,7 @@
         "dc:date": "2017-06-15T10:29:47-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6343/1134-e?rss=1",
         "isoDate": "2017-06-15T17:29:47.000Z"
       },
       {
@@ -65,6 +70,7 @@
         "dc:date": "2017-06-15T10:29:47-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6343/1134-f?rss=1",
         "isoDate": "2017-06-15T17:29:47.000Z"
       },
       {
@@ -76,6 +82,7 @@
         "dc:date": "2017-06-15T10:29:47-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6343/1134-g?rss=1",
         "isoDate": "2017-06-15T17:29:47.000Z"
       },
       {
@@ -87,6 +94,7 @@
         "dc:date": "2017-06-15T10:29:47-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6343/1134-h?rss=1",
         "isoDate": "2017-06-15T17:29:47.000Z"
       },
       {
@@ -98,6 +106,7 @@
         "dc:date": "2017-06-15T10:29:47-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6343/1134-i?rss=1",
         "isoDate": "2017-06-15T17:29:47.000Z"
       },
       {
@@ -109,6 +118,7 @@
         "dc:date": "2017-06-15T10:29:47-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6343/1134-j?rss=1",
         "isoDate": "2017-06-15T17:29:47.000Z"
       },
       {
@@ -120,6 +130,7 @@
         "dc:date": "2017-06-15T10:29:47-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6343/1134-k?rss=1",
         "isoDate": "2017-06-15T17:29:47.000Z"
       },
       {
@@ -131,6 +142,7 @@
         "dc:date": "2017-06-15T10:29:47-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6343/1134-l?rss=1",
         "isoDate": "2017-06-15T17:29:47.000Z"
       },
       {
@@ -142,6 +154,7 @@
         "dc:date": "2017-06-15T10:29:47-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6343/1134-m?rss=1",
         "isoDate": "2017-06-15T17:29:47.000Z"
       },
       {
@@ -153,6 +166,7 @@
         "dc:date": "2017-06-15T10:29:47-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6343/1134-n?rss=1",
         "isoDate": "2017-06-15T17:29:47.000Z"
       },
       {
@@ -164,6 +178,7 @@
         "dc:date": "2017-06-15T10:29:47-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6343/1134-o?rss=1",
         "isoDate": "2017-06-15T17:29:47.000Z"
       },
       {
@@ -175,6 +190,7 @@
         "dc:date": "2017-06-15T10:29:47-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6343/1134-p?rss=1",
         "isoDate": "2017-06-15T17:29:47.000Z"
       },
       {
@@ -186,6 +202,7 @@
         "dc:date": "2017-06-15T10:29:47-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6343/1134-q?rss=1",
         "isoDate": "2017-06-15T17:29:47.000Z"
       },
       {
@@ -197,6 +214,7 @@
         "dc:date": "2017-06-15T10:29:47-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6343/1134-r?rss=1",
         "isoDate": "2017-06-15T17:29:47.000Z"
       },
       {
@@ -208,6 +226,7 @@
         "dc:date": "2017-06-15T10:29:47-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6343/1134-s?rss=1",
         "isoDate": "2017-06-15T17:29:47.000Z"
       },
       {
@@ -219,6 +238,7 @@
         "dc:date": "2017-06-15T10:29:47-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6343/1134-t?rss=1",
         "isoDate": "2017-06-15T17:29:47.000Z"
       },
       {
@@ -230,6 +250,7 @@
         "dc:date": "2017-06-15T10:29:47-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6343/1134-u?rss=1",
         "isoDate": "2017-06-15T17:29:47.000Z"
       },
       {
@@ -241,6 +262,7 @@
         "dc:date": "2017-06-08T10:24:19-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6342/1040-a?rss=1",
         "isoDate": "2017-06-08T17:24:19.000Z"
       },
       {
@@ -252,6 +274,7 @@
         "dc:date": "2017-06-08T10:24:19-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6342/1040-b?rss=1",
         "isoDate": "2017-06-08T17:24:19.000Z"
       },
       {
@@ -263,6 +286,7 @@
         "dc:date": "2017-06-08T10:24:19-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6342/1040-c?rss=1",
         "isoDate": "2017-06-08T17:24:19.000Z"
       },
       {
@@ -274,6 +298,7 @@
         "dc:date": "2017-06-08T10:24:19-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6342/1040-d?rss=1",
         "isoDate": "2017-06-08T17:24:19.000Z"
       },
       {
@@ -285,6 +310,7 @@
         "dc:date": "2017-06-08T10:24:19-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6342/1040-e?rss=1",
         "isoDate": "2017-06-08T17:24:19.000Z"
       },
       {
@@ -296,6 +322,7 @@
         "dc:date": "2017-06-08T10:24:19-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6342/1040-f?rss=1",
         "isoDate": "2017-06-08T17:24:19.000Z"
       },
       {
@@ -307,6 +334,7 @@
         "dc:date": "2017-06-08T10:24:19-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6342/1040-g?rss=1",
         "isoDate": "2017-06-08T17:24:19.000Z"
       },
       {
@@ -318,6 +346,7 @@
         "dc:date": "2017-06-08T10:24:19-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6342/1040-h?rss=1",
         "isoDate": "2017-06-08T17:24:19.000Z"
       },
       {
@@ -329,6 +358,7 @@
         "dc:date": "2017-06-08T10:24:19-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6342/1040-i?rss=1",
         "isoDate": "2017-06-08T17:24:19.000Z"
       },
       {
@@ -340,6 +370,7 @@
         "dc:date": "2017-06-08T10:24:19-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6342/1040-j?rss=1",
         "isoDate": "2017-06-08T17:24:19.000Z"
       },
       {
@@ -351,6 +382,7 @@
         "dc:date": "2017-06-08T10:24:19-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6342/1040-k?rss=1",
         "isoDate": "2017-06-08T17:24:19.000Z"
       },
       {
@@ -362,6 +394,7 @@
         "dc:date": "2017-06-08T10:24:19-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6342/1040-l?rss=1",
         "isoDate": "2017-06-08T17:24:19.000Z"
       },
       {
@@ -373,6 +406,7 @@
         "dc:date": "2017-06-08T10:24:19-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6342/1040-m?rss=1",
         "isoDate": "2017-06-08T17:24:19.000Z"
       },
       {
@@ -384,6 +418,7 @@
         "dc:date": "2017-06-08T10:24:19-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6342/1040-n?rss=1",
         "isoDate": "2017-06-08T17:24:19.000Z"
       },
       {
@@ -395,6 +430,7 @@
         "dc:date": "2017-06-08T10:24:19-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6342/1040-o?rss=1",
         "isoDate": "2017-06-08T17:24:19.000Z"
       },
       {
@@ -406,6 +442,7 @@
         "dc:date": "2017-06-08T10:24:19-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6342/1040-p?rss=1",
         "isoDate": "2017-06-08T17:24:19.000Z"
       },
       {
@@ -417,6 +454,7 @@
         "dc:date": "2017-06-01T10:23:07-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6341/918-a?rss=1",
         "isoDate": "2017-06-01T17:23:07.000Z"
       },
       {
@@ -428,6 +466,7 @@
         "dc:date": "2017-06-01T10:23:07-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6341/918-b?rss=1",
         "isoDate": "2017-06-01T17:23:07.000Z"
       },
       {
@@ -439,6 +478,7 @@
         "dc:date": "2017-06-01T10:23:07-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6341/918-c?rss=1",
         "isoDate": "2017-06-01T17:23:07.000Z"
       },
       {
@@ -450,6 +490,7 @@
         "dc:date": "2017-06-01T10:23:07-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6341/918-d?rss=1",
         "isoDate": "2017-06-01T17:23:07.000Z"
       },
       {
@@ -461,6 +502,7 @@
         "dc:date": "2017-06-01T10:23:07-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6341/918-e?rss=1",
         "isoDate": "2017-06-01T17:23:07.000Z"
       },
       {
@@ -472,6 +514,7 @@
         "dc:date": "2017-06-01T10:23:07-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6341/918-f?rss=1",
         "isoDate": "2017-06-01T17:23:07.000Z"
       },
       {
@@ -483,6 +526,7 @@
         "dc:date": "2017-06-01T10:23:07-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6341/918-g?rss=1",
         "isoDate": "2017-06-01T17:23:07.000Z"
       },
       {
@@ -494,6 +538,7 @@
         "dc:date": "2017-06-01T10:23:07-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6341/918-h?rss=1",
         "isoDate": "2017-06-01T17:23:07.000Z"
       },
       {
@@ -505,6 +550,7 @@
         "dc:date": "2017-06-01T10:23:07-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6341/918-i?rss=1",
         "isoDate": "2017-06-01T17:23:07.000Z"
       },
       {
@@ -516,6 +562,7 @@
         "dc:date": "2017-06-01T10:23:07-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6341/918-j?rss=1",
         "isoDate": "2017-06-01T17:23:07.000Z"
       },
       {
@@ -527,6 +574,7 @@
         "dc:date": "2017-06-01T10:23:07-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6341/918-k?rss=1",
         "isoDate": "2017-06-01T17:23:07.000Z"
       },
       {
@@ -538,6 +586,7 @@
         "dc:date": "2017-06-01T10:23:07-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6341/918-l?rss=1",
         "isoDate": "2017-06-01T17:23:07.000Z"
       },
       {
@@ -549,6 +598,7 @@
         "dc:date": "2017-06-01T10:23:07-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6341/918-m?rss=1",
         "isoDate": "2017-06-01T17:23:07.000Z"
       },
       {
@@ -560,6 +610,7 @@
         "dc:date": "2017-06-01T10:23:07-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6341/918-n?rss=1",
         "isoDate": "2017-06-01T17:23:07.000Z"
       },
       {
@@ -571,6 +622,7 @@
         "dc:date": "2017-06-01T10:23:07-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6341/918-o?rss=1",
         "isoDate": "2017-06-01T17:23:07.000Z"
       },
       {
@@ -582,6 +634,7 @@
         "dc:date": "2017-06-01T10:23:07-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6341/918-p?rss=1",
         "isoDate": "2017-06-01T17:23:07.000Z"
       },
       {
@@ -593,6 +646,7 @@
         "dc:date": "2017-06-01T10:23:07-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6341/918-q?rss=1",
         "isoDate": "2017-06-01T17:23:07.000Z"
       },
       {
@@ -604,6 +658,7 @@
         "dc:date": "2017-05-25T10:24:10-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6340/816-a?rss=1",
         "isoDate": "2017-05-25T17:24:10.000Z"
       },
       {
@@ -615,6 +670,7 @@
         "dc:date": "2017-05-25T10:24:10-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6340/816-b?rss=1",
         "isoDate": "2017-05-25T17:24:10.000Z"
       },
       {
@@ -626,6 +682,7 @@
         "dc:date": "2017-05-25T10:24:10-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6340/816-c?rss=1",
         "isoDate": "2017-05-25T17:24:10.000Z"
       },
       {
@@ -637,6 +694,7 @@
         "dc:date": "2017-05-25T10:24:10-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6340/816-d?rss=1",
         "isoDate": "2017-05-25T17:24:10.000Z"
       },
       {
@@ -648,6 +706,7 @@
         "dc:date": "2017-05-25T10:24:10-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6340/816-e?rss=1",
         "isoDate": "2017-05-25T17:24:10.000Z"
       },
       {
@@ -659,6 +718,7 @@
         "dc:date": "2017-05-25T10:24:10-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6340/816-f?rss=1",
         "isoDate": "2017-05-25T17:24:10.000Z"
       },
       {
@@ -670,6 +730,7 @@
         "dc:date": "2017-05-25T10:24:10-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6340/816-g?rss=1",
         "isoDate": "2017-05-25T17:24:10.000Z"
       },
       {
@@ -681,6 +742,7 @@
         "dc:date": "2017-05-25T10:24:10-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6340/816-h?rss=1",
         "isoDate": "2017-05-25T17:24:10.000Z"
       },
       {
@@ -692,6 +754,7 @@
         "dc:date": "2017-05-25T10:24:10-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6340/816-i?rss=1",
         "isoDate": "2017-05-25T17:24:10.000Z"
       },
       {
@@ -703,6 +766,7 @@
         "dc:date": "2017-05-25T10:24:10-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6340/816-j?rss=1",
         "isoDate": "2017-05-25T17:24:10.000Z"
       },
       {
@@ -714,6 +778,7 @@
         "dc:date": "2017-05-25T10:24:10-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6340/816-k?rss=1",
         "isoDate": "2017-05-25T17:24:10.000Z"
       },
       {
@@ -725,6 +790,7 @@
         "dc:date": "2017-05-25T10:24:10-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6340/816-l?rss=1",
         "isoDate": "2017-05-25T17:24:10.000Z"
       },
       {
@@ -736,6 +802,7 @@
         "dc:date": "2017-05-25T10:24:10-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6340/816-m?rss=1",
         "isoDate": "2017-05-25T17:24:10.000Z"
       },
       {
@@ -747,6 +814,7 @@
         "dc:date": "2017-05-25T10:24:10-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6340/816-n?rss=1",
         "isoDate": "2017-05-25T17:24:10.000Z"
       },
       {
@@ -758,6 +826,7 @@
         "dc:date": "2017-05-25T10:24:10-07:00",
         "content": "",
         "contentSnippet": "",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6340/816-o?rss=1",
         "isoDate": "2017-05-25T17:24:10.000Z"
       }
     ],

--- a/test/output/xml2js-options.json
+++ b/test/output/xml2js-options.json
@@ -10,6 +10,7 @@
         "dc:date": "2017-06-15T10:29:47-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6343/1134-a?rss=1",
         "isoDate": "2017-06-15T17:29:47.000Z"
       },
       {
@@ -21,6 +22,7 @@
         "dc:date": "2017-06-15T10:29:47-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6343/1134-b?rss=1",
         "isoDate": "2017-06-15T17:29:47.000Z"
       },
       {
@@ -32,6 +34,7 @@
         "dc:date": "2017-06-15T10:29:47-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6343/1134-c?rss=1",
         "isoDate": "2017-06-15T17:29:47.000Z"
       },
       {
@@ -43,6 +46,7 @@
         "dc:date": "2017-06-15T10:29:47-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6343/1134-d?rss=1",
         "isoDate": "2017-06-15T17:29:47.000Z"
       },
       {
@@ -54,6 +58,7 @@
         "dc:date": "2017-06-15T10:29:47-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6343/1134-e?rss=1",
         "isoDate": "2017-06-15T17:29:47.000Z"
       },
       {
@@ -65,6 +70,7 @@
         "dc:date": "2017-06-15T10:29:47-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6343/1134-f?rss=1",
         "isoDate": "2017-06-15T17:29:47.000Z"
       },
       {
@@ -76,6 +82,7 @@
         "dc:date": "2017-06-15T10:29:47-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6343/1134-g?rss=1",
         "isoDate": "2017-06-15T17:29:47.000Z"
       },
       {
@@ -87,6 +94,7 @@
         "dc:date": "2017-06-15T10:29:47-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6343/1134-h?rss=1",
         "isoDate": "2017-06-15T17:29:47.000Z"
       },
       {
@@ -98,6 +106,7 @@
         "dc:date": "2017-06-15T10:29:47-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6343/1134-i?rss=1",
         "isoDate": "2017-06-15T17:29:47.000Z"
       },
       {
@@ -109,6 +118,7 @@
         "dc:date": "2017-06-15T10:29:47-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6343/1134-j?rss=1",
         "isoDate": "2017-06-15T17:29:47.000Z"
       },
       {
@@ -120,6 +130,7 @@
         "dc:date": "2017-06-15T10:29:47-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6343/1134-k?rss=1",
         "isoDate": "2017-06-15T17:29:47.000Z"
       },
       {
@@ -131,6 +142,7 @@
         "dc:date": "2017-06-15T10:29:47-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6343/1134-l?rss=1",
         "isoDate": "2017-06-15T17:29:47.000Z"
       },
       {
@@ -142,6 +154,7 @@
         "dc:date": "2017-06-15T10:29:47-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6343/1134-m?rss=1",
         "isoDate": "2017-06-15T17:29:47.000Z"
       },
       {
@@ -153,6 +166,7 @@
         "dc:date": "2017-06-15T10:29:47-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6343/1134-n?rss=1",
         "isoDate": "2017-06-15T17:29:47.000Z"
       },
       {
@@ -164,6 +178,7 @@
         "dc:date": "2017-06-15T10:29:47-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6343/1134-o?rss=1",
         "isoDate": "2017-06-15T17:29:47.000Z"
       },
       {
@@ -175,6 +190,7 @@
         "dc:date": "2017-06-15T10:29:47-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6343/1134-p?rss=1",
         "isoDate": "2017-06-15T17:29:47.000Z"
       },
       {
@@ -186,6 +202,7 @@
         "dc:date": "2017-06-15T10:29:47-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6343/1134-q?rss=1",
         "isoDate": "2017-06-15T17:29:47.000Z"
       },
       {
@@ -197,6 +214,7 @@
         "dc:date": "2017-06-15T10:29:47-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6343/1134-r?rss=1",
         "isoDate": "2017-06-15T17:29:47.000Z"
       },
       {
@@ -208,6 +226,7 @@
         "dc:date": "2017-06-15T10:29:47-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6343/1134-s?rss=1",
         "isoDate": "2017-06-15T17:29:47.000Z"
       },
       {
@@ -219,6 +238,7 @@
         "dc:date": "2017-06-15T10:29:47-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6343/1134-t?rss=1",
         "isoDate": "2017-06-15T17:29:47.000Z"
       },
       {
@@ -230,6 +250,7 @@
         "dc:date": "2017-06-15T10:29:47-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6343/1134-u?rss=1",
         "isoDate": "2017-06-15T17:29:47.000Z"
       },
       {
@@ -241,6 +262,7 @@
         "dc:date": "2017-06-08T10:24:19-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6342/1040-a?rss=1",
         "isoDate": "2017-06-08T17:24:19.000Z"
       },
       {
@@ -252,6 +274,7 @@
         "dc:date": "2017-06-08T10:24:19-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6342/1040-b?rss=1",
         "isoDate": "2017-06-08T17:24:19.000Z"
       },
       {
@@ -263,6 +286,7 @@
         "dc:date": "2017-06-08T10:24:19-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6342/1040-c?rss=1",
         "isoDate": "2017-06-08T17:24:19.000Z"
       },
       {
@@ -274,6 +298,7 @@
         "dc:date": "2017-06-08T10:24:19-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6342/1040-d?rss=1",
         "isoDate": "2017-06-08T17:24:19.000Z"
       },
       {
@@ -285,6 +310,7 @@
         "dc:date": "2017-06-08T10:24:19-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6342/1040-e?rss=1",
         "isoDate": "2017-06-08T17:24:19.000Z"
       },
       {
@@ -296,6 +322,7 @@
         "dc:date": "2017-06-08T10:24:19-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6342/1040-f?rss=1",
         "isoDate": "2017-06-08T17:24:19.000Z"
       },
       {
@@ -307,6 +334,7 @@
         "dc:date": "2017-06-08T10:24:19-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6342/1040-g?rss=1",
         "isoDate": "2017-06-08T17:24:19.000Z"
       },
       {
@@ -318,6 +346,7 @@
         "dc:date": "2017-06-08T10:24:19-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6342/1040-h?rss=1",
         "isoDate": "2017-06-08T17:24:19.000Z"
       },
       {
@@ -329,6 +358,7 @@
         "dc:date": "2017-06-08T10:24:19-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6342/1040-i?rss=1",
         "isoDate": "2017-06-08T17:24:19.000Z"
       },
       {
@@ -340,6 +370,7 @@
         "dc:date": "2017-06-08T10:24:19-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6342/1040-j?rss=1",
         "isoDate": "2017-06-08T17:24:19.000Z"
       },
       {
@@ -351,6 +382,7 @@
         "dc:date": "2017-06-08T10:24:19-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6342/1040-k?rss=1",
         "isoDate": "2017-06-08T17:24:19.000Z"
       },
       {
@@ -362,6 +394,7 @@
         "dc:date": "2017-06-08T10:24:19-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6342/1040-l?rss=1",
         "isoDate": "2017-06-08T17:24:19.000Z"
       },
       {
@@ -373,6 +406,7 @@
         "dc:date": "2017-06-08T10:24:19-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6342/1040-m?rss=1",
         "isoDate": "2017-06-08T17:24:19.000Z"
       },
       {
@@ -384,6 +418,7 @@
         "dc:date": "2017-06-08T10:24:19-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6342/1040-n?rss=1",
         "isoDate": "2017-06-08T17:24:19.000Z"
       },
       {
@@ -395,6 +430,7 @@
         "dc:date": "2017-06-08T10:24:19-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6342/1040-o?rss=1",
         "isoDate": "2017-06-08T17:24:19.000Z"
       },
       {
@@ -406,6 +442,7 @@
         "dc:date": "2017-06-08T10:24:19-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6342/1040-p?rss=1",
         "isoDate": "2017-06-08T17:24:19.000Z"
       },
       {
@@ -417,6 +454,7 @@
         "dc:date": "2017-06-01T10:23:07-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6341/918-a?rss=1",
         "isoDate": "2017-06-01T17:23:07.000Z"
       },
       {
@@ -428,6 +466,7 @@
         "dc:date": "2017-06-01T10:23:07-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6341/918-b?rss=1",
         "isoDate": "2017-06-01T17:23:07.000Z"
       },
       {
@@ -439,6 +478,7 @@
         "dc:date": "2017-06-01T10:23:07-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6341/918-c?rss=1",
         "isoDate": "2017-06-01T17:23:07.000Z"
       },
       {
@@ -450,6 +490,7 @@
         "dc:date": "2017-06-01T10:23:07-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6341/918-d?rss=1",
         "isoDate": "2017-06-01T17:23:07.000Z"
       },
       {
@@ -461,6 +502,7 @@
         "dc:date": "2017-06-01T10:23:07-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6341/918-e?rss=1",
         "isoDate": "2017-06-01T17:23:07.000Z"
       },
       {
@@ -472,6 +514,7 @@
         "dc:date": "2017-06-01T10:23:07-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6341/918-f?rss=1",
         "isoDate": "2017-06-01T17:23:07.000Z"
       },
       {
@@ -483,6 +526,7 @@
         "dc:date": "2017-06-01T10:23:07-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6341/918-g?rss=1",
         "isoDate": "2017-06-01T17:23:07.000Z"
       },
       {
@@ -494,6 +538,7 @@
         "dc:date": "2017-06-01T10:23:07-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6341/918-h?rss=1",
         "isoDate": "2017-06-01T17:23:07.000Z"
       },
       {
@@ -505,6 +550,7 @@
         "dc:date": "2017-06-01T10:23:07-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6341/918-i?rss=1",
         "isoDate": "2017-06-01T17:23:07.000Z"
       },
       {
@@ -516,6 +562,7 @@
         "dc:date": "2017-06-01T10:23:07-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6341/918-j?rss=1",
         "isoDate": "2017-06-01T17:23:07.000Z"
       },
       {
@@ -527,6 +574,7 @@
         "dc:date": "2017-06-01T10:23:07-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6341/918-k?rss=1",
         "isoDate": "2017-06-01T17:23:07.000Z"
       },
       {
@@ -538,6 +586,7 @@
         "dc:date": "2017-06-01T10:23:07-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6341/918-l?rss=1",
         "isoDate": "2017-06-01T17:23:07.000Z"
       },
       {
@@ -549,6 +598,7 @@
         "dc:date": "2017-06-01T10:23:07-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6341/918-m?rss=1",
         "isoDate": "2017-06-01T17:23:07.000Z"
       },
       {
@@ -560,6 +610,7 @@
         "dc:date": "2017-06-01T10:23:07-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6341/918-n?rss=1",
         "isoDate": "2017-06-01T17:23:07.000Z"
       },
       {
@@ -571,6 +622,7 @@
         "dc:date": "2017-06-01T10:23:07-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6341/918-o?rss=1",
         "isoDate": "2017-06-01T17:23:07.000Z"
       },
       {
@@ -582,6 +634,7 @@
         "dc:date": "2017-06-01T10:23:07-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6341/918-p?rss=1",
         "isoDate": "2017-06-01T17:23:07.000Z"
       },
       {
@@ -593,6 +646,7 @@
         "dc:date": "2017-06-01T10:23:07-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6341/918-q?rss=1",
         "isoDate": "2017-06-01T17:23:07.000Z"
       },
       {
@@ -604,6 +658,7 @@
         "dc:date": "2017-05-25T10:24:10-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6340/816-a?rss=1",
         "isoDate": "2017-05-25T17:24:10.000Z"
       },
       {
@@ -615,6 +670,7 @@
         "dc:date": "2017-05-25T10:24:10-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6340/816-b?rss=1",
         "isoDate": "2017-05-25T17:24:10.000Z"
       },
       {
@@ -626,6 +682,7 @@
         "dc:date": "2017-05-25T10:24:10-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6340/816-c?rss=1",
         "isoDate": "2017-05-25T17:24:10.000Z"
       },
       {
@@ -637,6 +694,7 @@
         "dc:date": "2017-05-25T10:24:10-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6340/816-d?rss=1",
         "isoDate": "2017-05-25T17:24:10.000Z"
       },
       {
@@ -648,6 +706,7 @@
         "dc:date": "2017-05-25T10:24:10-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6340/816-e?rss=1",
         "isoDate": "2017-05-25T17:24:10.000Z"
       },
       {
@@ -659,6 +718,7 @@
         "dc:date": "2017-05-25T10:24:10-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6340/816-f?rss=1",
         "isoDate": "2017-05-25T17:24:10.000Z"
       },
       {
@@ -670,6 +730,7 @@
         "dc:date": "2017-05-25T10:24:10-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6340/816-g?rss=1",
         "isoDate": "2017-05-25T17:24:10.000Z"
       },
       {
@@ -681,6 +742,7 @@
         "dc:date": "2017-05-25T10:24:10-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6340/816-h?rss=1",
         "isoDate": "2017-05-25T17:24:10.000Z"
       },
       {
@@ -692,6 +754,7 @@
         "dc:date": "2017-05-25T10:24:10-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6340/816-i?rss=1",
         "isoDate": "2017-05-25T17:24:10.000Z"
       },
       {
@@ -703,6 +766,7 @@
         "dc:date": "2017-05-25T10:24:10-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6340/816-j?rss=1",
         "isoDate": "2017-05-25T17:24:10.000Z"
       },
       {
@@ -714,6 +778,7 @@
         "dc:date": "2017-05-25T10:24:10-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6340/816-k?rss=1",
         "isoDate": "2017-05-25T17:24:10.000Z"
       },
       {
@@ -725,6 +790,7 @@
         "dc:date": "2017-05-25T10:24:10-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6340/816-l?rss=1",
         "isoDate": "2017-05-25T17:24:10.000Z"
       },
       {
@@ -736,6 +802,7 @@
         "dc:date": "2017-05-25T10:24:10-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6340/816-m?rss=1",
         "isoDate": "2017-05-25T17:24:10.000Z"
       },
       {
@@ -747,6 +814,7 @@
         "dc:date": "2017-05-25T10:24:10-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6340/816-n?rss=1",
         "isoDate": "2017-05-25T17:24:10.000Z"
       },
       {
@@ -758,6 +826,7 @@
         "dc:date": "2017-05-25T10:24:10-07:00",
         "content": "EMPTY",
         "contentSnippet": "EMPTY",
+        "rdf:about": "http://science.sciencemag.org/cgi/content/short/356/6340/816-o?rss=1",
         "isoDate": "2017-05-25T17:24:10.000Z"
       }
     ],


### PR DESCRIPTION
Apparently, `rdf:about` is not always present.
So it makes sense to verify its existence before accessing it.  Simple `if` does the job.

Besides, some *mock* results in the *test/output* folder have to be regenerated to include `rdf:about`.
