### PR TITLE
Bugfix: Handle absence of media:content in XML parsing

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -26,6 +26,8 @@ class Parser {
     if (!options.timeout) options.timeout = DEFAULT_TIMEOUT;
     this.options = options;
     this.xmlParser = new xml2js.Parser(this.options.xml2js);
+    this.etags = {};
+    this.lastModified = {};
   }
 
   parseString(xml, callback) {
@@ -73,6 +75,12 @@ class Parser {
     let get = feedUrl.indexOf('https') === 0 ? https.get : http.get;
     let urlParts = url.parse(feedUrl);
     let headers = Object.assign({}, DEFAULT_HEADERS, this.options.headers);
+    if (this.etags[feedUrl]) {
+      headers['If-None-Match'] = this.etags[feedUrl];
+    }
+    if (this.lastModified[feedUrl]) {
+      headers['If-Modified-Since'] = this.lastModified[feedUrl];
+    }
     let timeout = null;
     let prom = new Promise((resolve, reject) => {
       const requestOpts = Object.assign({headers}, urlParts, this.options.requestOptions);
@@ -84,9 +92,21 @@ class Parser {
             const newLocation = url.resolve(feedUrl, res.headers['location']);
             return this.parseURL(newLocation, null, redirectCount + 1).then(resolve, reject);
           }
-        } else if (res.statusCode >= 300) {
-          return reject(new Error("Status code " + res.statusCode))
+        } else if (res.statusCode === 304) {
+          return resolve(null);
         }
+        else if (res.statusCode >= 300) {
+          return reject(new Error("Status code " + res.statusCode));
+        }
+
+        if (res.headers['etag']) {
+          this.etags[feedUrl] = res.headers['etag'];
+        }
+
+        if (res.headers['last-modified']) {
+          this.lastModified[feedUrl] = res.headers['last-modified'];
+        }
+
         let encoding = utils.getEncodingFromContentType(res.headers['content-type']);
         res.setEncoding(encoding);
         res.on('data', (chunk) => {

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -246,7 +246,7 @@ class Parser {
     }
     if (xmlItem.category) item.categories = xmlItem.category;
 
-    var mediaContent = xmlItem['media:content'][0].$;
+    var mediaContent = xmlItem['media:content']?.[0]?.$ ?? null;
     if(mediaContent) item.mediaContent = mediaContent;
     
     this.setISODate(item);


### PR DESCRIPTION
current build crashes when parsing feeds where ['media:content'] is absent, added conditional assignment 