### PR TITLE
Fix delete text inside elements

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,7 +3,7 @@ const entities = require('entities');
 const xml2js = require('xml2js');
 
 utils.stripHtml = function(str) {
-  str = str.replace(/([^\n])<\/?(h|br|p|ul|ol|li|blockquote|section|table|tr|div)(?:.|\n)*?>([^\n])/gm, '$1\n$3')
+  str = str.replace(/<\/?(h|br|p|ul|ol|li|blockquote|section|table|tr|div)(?:.|\n)*?>/gm, '\n');
   str = str.replace(/<(?:.|\n)*?>/gm, '');
   return str;
 }


### PR DESCRIPTION
for text like this:
```
'<br/><strong>כגךדלמגכ דגלכחךדגכ</strong><br />
דגלחכממ דגךכלח שדגכמגכמל דךגלכח דךגלחכדךג דךגיכחדמגכ דגחכךדלמגכך שךדליכדחגמכ דגכד<br />
<a href="tg://resolve?domain=@" rel="nofollow">@</a>'
```

all the text between the br will be deletet without this fix