### PR TITLE
Add subtitle field to feed fields

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -59,6 +59,7 @@ declare namespace Parser {
     items: (U & Item)[];
     feedUrl?: string;
     description?: string;
+    subtitle?: string;
     itunes?: {
       [key: string]: any;
       image?: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -59,7 +59,7 @@ declare namespace Parser {
     items: (U & Item)[];
     feedUrl?: string;
     description?: string;
-    subtitle?: string;
+    subtitle?: string; // Atom feeds use <subtitle> for feed description
     itunes?: {
       [key: string]: any;
       image?: string;

--- a/lib/fields.js
+++ b/lib/fields.js
@@ -9,7 +9,7 @@ fields.feed = [
   ['dc:type', 'type'],
   'title',
   'description',
-  'subtitle',
+  'subtitle', // Atom feeds use <subtitle> for feed description
   'author',
   'pubDate',
   'webMaster',

--- a/lib/fields.js
+++ b/lib/fields.js
@@ -9,6 +9,7 @@ fields.feed = [
   ['dc:type', 'type'],
   'title',
   'description',
+  'subtitle',
   'author',
   'pubDate',
   'webMaster',


### PR DESCRIPTION
## Summary

This PR adds a `subtitle` field to the list of feed fields, enabling the parser to automatically extract the `<subtitle>` element from RSS feeds.

## Changes

- **`lib/fields.js`**: Added `'subtitle'` to the `fields.feed` array
- **`index.d.ts`**: Added `subtitle?: string;` to the TypeScript `Output` interface for proper type definitions

## Motivation

The `subtitle` field is a common RSS feed element that provides additional descriptive information about a feed. This change allows users to access this field without needing to configure custom fields.

## Testing

All existing tests pass (38/38).

@rbren can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)