### PR TITLE
Fix CVE-2022-46175: Update json5 to 2.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "entities": "^2.0.3",
+        "json5": "^2.2.2",
         "webpack": "^5.90.1",
         "webpack-cli": "^5.1.4",
         "xml2js": "^0.5.0"
@@ -25,6 +26,9 @@
         "express": "^4.16.3",
         "mocha": "^10.2.0",
         "puppeteer": "^22.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -78,6 +82,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@babel/generator": {
@@ -3579,10 +3596,11 @@
       "dev": true
     },
     "node_modules/diff": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
-      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
+      "integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
       }
@@ -4726,10 +4744,10 @@
       "dev": true
     },
     "node_modules/json5": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.2.tgz",
+      "integrity": "sha512-46Tk9JiOL2z7ytNQWFLpj99RZkVgeHf87yGQKsIkaPz1qSH9UczKH1rO7K3wgRselo0tYMUNfecYpm/p1vC7tQ==",
+      "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "xml2js": "^0.5.0"
       },
       "devDependencies": {
-        "@babel/core": "^7.21.4",
+        "@babel/core": "^7.23.2",
         "@babel/preset-env": "^7.21.4",
         "@types/xml2js": "^0.4.3",
         "babel-core": "^6.26.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5020,7 +5020,7 @@
         "browser-stdout": "^1.3.1",
         "chokidar": "^3.5.3",
         "debug": "^4.3.5",
-        "diff": "^5.2.0",
+        "diff": "^8.0.3",
         "escape-string-regexp": "^4.0.0",
         "find-up": "^5.0.0",
         "glob": "^8.1.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "Bobby Brennan",
   "license": "MIT",
   "devDependencies": {
-    "@babel/core": "^7.21.4",
+    "@babel/core": "^7.23.2",
     "@babel/preset-env": "^7.21.4",
     "@types/xml2js": "^0.4.3",
     "babel-core": "^6.26.3",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "entities": "^2.0.3",
+    "json5": "^2.2.2",
     "webpack": "^5.90.1",
     "webpack-cli": "^5.1.4",
     "xml2js": "^0.5.0"


### PR DESCRIPTION
Security fix for CVE-2022-46175