### PR TITLE
fix: decompress gzip/deflate/br responses in parseURL()

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -1,6 +1,7 @@
 "use strict";
 const http = require('http');
 const https = require('https');
+const zlib = require('zlib');
 const xml2js = require('xml2js');
 const url = require('url');
 
@@ -10,6 +11,7 @@ const utils = require('./utils');
 const DEFAULT_HEADERS = {
   'User-Agent': 'rss-parser',
   'Accept': 'application/rss+xml',
+  'Accept-Encoding': 'gzip, deflate, br',
 }
 const DEFAULT_MAX_REDIRECTS = 5;
 const DEFAULT_TIMEOUT = 60000;
@@ -108,11 +110,21 @@ class Parser {
         }
 
         let encoding = utils.getEncodingFromContentType(res.headers['content-type']);
-        res.setEncoding(encoding);
-        res.on('data', (chunk) => {
+        let contentEncoding = (res.headers['content-encoding'] || '').toLowerCase();
+        let stream = res;
+        if (contentEncoding === 'gzip' || contentEncoding === 'x-gzip') {
+          stream = res.pipe(zlib.createGunzip());
+        } else if (contentEncoding === 'deflate' || contentEncoding === 'x-deflate') {
+          stream = res.pipe(zlib.createInflate());
+        } else if (contentEncoding === 'br') {
+          stream = res.pipe(zlib.createBrotliDecompress());
+        }
+        stream.setEncoding(encoding);
+        stream.on('data', (chunk) => {
           xml += chunk;
         });
-        res.on('end', () => {
+        stream.on('error', reject);
+        stream.on('end', () => {
           return this.parseString(xml).then(resolve, reject);
         });
       })

--- a/test/parser.js
+++ b/test/parser.js
@@ -2,6 +2,7 @@
 
 var fs = require('fs');
 var HTTP = require('http');
+var Zlib = require('zlib');
 
 var Parser = require('../index.js');
 
@@ -206,6 +207,28 @@ describe('Parser', function() {
           var expected = JSON.parse(fs.readFileSync(OUTPUT_FILE, 'utf8'));
           Expect({feed: parsed}).to.deep.equal(expected);
         }
+        server.close();
+        done();
+      });
+    });
+  });
+
+  it('should parse URL that returns gzip-compressed data even without an Accept-Encoding request', function(done) {
+    var INPUT_FILE = __dirname + '/input/reddit.rss';
+    var OUTPUT_FILE = __dirname + '/output/reddit.json';
+    var server = HTTP.createServer(function(req, res) {
+      var gzipped = Zlib.gzipSync(fs.readFileSync(INPUT_FILE));
+      res.setHeader('Content-Encoding', 'gzip');
+      res.end(gzipped);
+    });
+    server.listen(function() {
+      var port = server.address().port;
+      var url = 'http://localhost:' + port;
+      let parser = new Parser();
+      parser.parseURL(url, function(err, parsed) {
+        Expect(err).to.equal(null);
+        var expected = JSON.parse(fs.readFileSync(OUTPUT_FILE, 'utf8'));
+        Expect({feed: parsed}).to.deep.equal(expected);
         server.close();
         done();
       });


### PR DESCRIPTION
## Summary

Fixes #280. `parseURL()` never sends an `Accept-Encoding` header, and reads the raw HTTP response body directly as text (`res.on('data')`). Per RFC 7231 §5.3.4, a server is allowed to compress a response even without an `Accept-Encoding` request header - and as the issue reports, some servers do this unconditionally regardless of what's requested. When that happens, rss-parser feeds raw gzip bytes to the XML parser and fails with `Non-whitespace before first tag`.

Browsers and `fetch()` handle this by transparently decompressing based on the response's `Content-Encoding`, independent of what was requested. This PR does the same.

## Changes
- `parseURL()` now sends `Accept-Encoding: gzip, deflate, br` by default (in `DEFAULT_HEADERS`), for better compliance and so compliant servers can save bandwidth.
- Regardless of what's requested, if the response actually comes back with a `Content-Encoding: gzip`/`deflate`/`br` header, the body is piped through the matching `zlib` decompression stream before being read as text - covering the case in the issue where the server ignores `Accept-Encoding` entirely.

## Test plan
- [x] Added a test that spins up a real HTTP server returning a gzip-compressed RSS body with a `Content-Encoding: gzip` header and no request for it, and asserts it parses correctly. Confirmed it fails with the exact `Non-whitespace before first tag` error from the issue when run against the old code, and passes with the fix.
- [x] Full existing test suite passes (36/36).